### PR TITLE
Correct library path, lib part of library name is implicit with dynamic linking.

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -9,5 +9,5 @@
 	"authors": [
 		"Craig Dillabaugh"
 	],
-	"libs" : ["libshp"]
+	"libs" : ["shp"]
 }


### PR DESCRIPTION
As the linker would then look for "liblibshp" rather than "libshp" which is what's there.
